### PR TITLE
feat: Mekanism native energy integration via IStrictEnergyHandler

### DIFF
--- a/src/main/java/backpackarsenal/compat/mekanism/MekanismCompat.java
+++ b/src/main/java/backpackarsenal/compat/mekanism/MekanismCompat.java
@@ -1,0 +1,94 @@
+package backpackarsenal.compat.mekanism;
+
+import backpackarsenal.BackpackArsenalMod;
+import backpackarsenal.energy.BackpackFeProvider;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.fml.ModList;
+
+/**
+ * Mekanism mod が読み込まれているときだけ Mekanism API を触る dispatcher。
+ *
+ * 重要: **このクラスは Mekanism の型を import しない**。 Mekanism 型を import するクラス
+ * ({@link MekanismEnergyAdapter}) は {@link #attachStrictEnergyCap} の内側で初めて
+ * 参照される。 JVM の lazy class loading により、 Mekanism 未導入環境では
+ * MekanismEnergyAdapter は class load されない → NoClassDefFoundError にならない。
+ *
+ * 利用側 ( {@code BackpackFeEvents.onAttachBlockEntity} ) は無条件に
+ * {@link #tryAttachStrictEnergy} を呼ぶだけで OK。
+ */
+public final class MekanismCompat {
+
+    private MekanismCompat() {}
+
+    /** {@code Capability<IStrictEnergyHandler>} の取得は Mekanism 未導入時に失敗するので
+     *  reflective に一度だけ取って cache する。 取得不可なら null。 */
+    private static Object cachedCap = null; // 実体は Capability<IStrictEnergyHandler>
+    private static boolean capLookupAttempted = false;
+
+    private static final ResourceLocation STRICT_ENERGY_KEY =
+        new ResourceLocation(BackpackArsenalMod.MODID, "mekanism_strict_energy");
+
+    /** Mekanism mod がロードされているか。 */
+    public static boolean isMekanismLoaded() {
+        return ModList.get().isLoaded("mekanism");
+    }
+
+    /**
+     * Mekanism がロードされていれば、 BE に Mekanism の STRICT_ENERGY capability を attach する。
+     * これにより Mekanism cube / cable は backpack を **native の発電機** として認識する。
+     */
+    public static void tryAttachStrictEnergy(AttachCapabilitiesEvent<BlockEntity> event,
+                                             BackpackFeProvider provider) {
+        if (!isMekanismLoaded()) return;
+        try {
+            attachStrictEnergyCap(event, provider);
+        } catch (Throwable t) {
+            BackpackArsenalMod.LOGGER.warn(
+                "[backpack_arsenal] failed to attach Mekanism STRICT_ENERGY cap: {}", t.toString());
+        }
+    }
+
+    /** Mekanism API を実際に触る部分。 ここから先のスタックが Mekanism class load を起こす。 */
+    private static void attachStrictEnergyCap(AttachCapabilitiesEvent<BlockEntity> event,
+                                              BackpackFeProvider provider) {
+        @SuppressWarnings("unchecked")
+        Capability<mekanism.api.energy.IStrictEnergyHandler> cap =
+            (Capability<mekanism.api.energy.IStrictEnergyHandler>) resolveStrictEnergyCap();
+        if (cap == null) return;
+
+        MekanismEnergyAdapter adapter = new MekanismEnergyAdapter(provider.storage);
+        LazyOptional<mekanism.api.energy.IStrictEnergyHandler> opt = LazyOptional.of(() -> adapter);
+        ICapabilityProvider mekProvider = new ICapabilityProvider() {
+            @Override
+            public <T> LazyOptional<T> getCapability(Capability<T> queriedCap,
+                                                    net.minecraft.core.Direction side) {
+                return queriedCap == cap ? opt.cast() : LazyOptional.empty();
+            }
+        };
+        event.addCapability(STRICT_ENERGY_KEY, mekProvider);
+        event.addListener(opt::invalidate);
+        BackpackArsenalMod.LOGGER.info(
+            "[backpack_arsenal] attached Mekanism STRICT_ENERGY cap to BE @ {}",
+            event.getObject().getBlockPos());
+    }
+
+    /** {@code mekanism.common.capabilities.Capabilities.STRICT_ENERGY} を解決。
+     *  Mekanism class が無い環境ではここで NoClassDefFoundError → 呼び出し側で catch される。 */
+    private static Object resolveStrictEnergyCap() {
+        if (capLookupAttempted) return cachedCap;
+        capLookupAttempted = true;
+        try {
+            cachedCap = mekanism.common.capabilities.Capabilities.STRICT_ENERGY;
+        } catch (Throwable t) {
+            BackpackArsenalMod.LOGGER.warn(
+                "[backpack_arsenal] Mekanism.Capabilities.STRICT_ENERGY lookup failed: {}", t.toString());
+            cachedCap = null;
+        }
+        return cachedCap;
+    }
+}

--- a/src/main/java/backpackarsenal/compat/mekanism/MekanismEnergyAdapter.java
+++ b/src/main/java/backpackarsenal/compat/mekanism/MekanismEnergyAdapter.java
@@ -1,0 +1,86 @@
+package backpackarsenal.compat.mekanism;
+
+import backpackarsenal.energy.BackpackFeStorage;
+import mekanism.api.Action;
+import mekanism.api.energy.IStrictEnergyHandler;
+import mekanism.api.math.FloatingLong;
+
+/**
+ * Mekanism native energy 連携の adapter。 {@link BackpackFeStorage} を
+ * Mekanism の {@link IStrictEnergyHandler} として公開する。
+ *
+ * これで Mekanism 側 (Energy Cube / Universal Cable / Induction Matrix) は
+ * 我々の backpack を **「Mekanism native の発電機」** として認識する。
+ * FE ↔ Joules の変換ブリッジを通さないので Mekanism config の
+ * {@code JoulesToForge} の影響を受けない。
+ *
+ * <p>変換方針: 内部 FE 値を <b>1 FE = 1 J</b> として扱う ( = 数値そのまま)。
+ * Mekanism の標準 (1 FE = 2.5 J) より厳しいレートだが、 user は Mekanism config
+ * で調整可能。</p>
+ *
+ * <p>この class は Mekanism API の型を import しているため、 Mekanism が
+ * 読み込まれていない環境で**class load してはいけない**。
+ * {@link MekanismCompat} がロード判定を行ったうえで初めて参照する。</p>
+ */
+public class MekanismEnergyAdapter implements IStrictEnergyHandler {
+
+    private final BackpackFeStorage storage;
+
+    public MekanismEnergyAdapter(BackpackFeStorage storage) {
+        this.storage = storage;
+    }
+
+    @Override
+    public int getEnergyContainerCount() {
+        return 1; // 1 つの container だけ持つ単純な発電機
+    }
+
+    @Override
+    public FloatingLong getEnergy(int container) {
+        if (container != 0) return FloatingLong.ZERO;
+        return FloatingLong.createConst(storage.getEnergyStored());
+    }
+
+    @Override
+    public void setEnergy(int container, FloatingLong energy) {
+        if (container != 0) return;
+        // FloatingLong → int 変換 (overflow しないよう clamp)
+        long v = Math.min(energy.longValue(), storage.getMaxEnergyStored());
+        storage.setEnergy((int) Math.max(0, v));
+    }
+
+    @Override
+    public FloatingLong getMaxEnergy(int container) {
+        if (container != 0) return FloatingLong.ZERO;
+        return FloatingLong.createConst(storage.getMaxEnergyStored());
+    }
+
+    @Override
+    public FloatingLong getNeededEnergy(int container) {
+        if (container != 0) return FloatingLong.ZERO;
+        int need = storage.getMaxEnergyStored() - storage.getEnergyStored();
+        return FloatingLong.createConst(Math.max(0, need));
+    }
+
+    /**
+     * 外部からの注入は受け付けない (発電専用)。 渡された量をそのまま「未受け取り」として返す。
+     */
+    @Override
+    public FloatingLong insertEnergy(int container, FloatingLong amount, Action action) {
+        return amount;
+    }
+
+    /**
+     * 外部 (Mekanism cable / cube) からの取り出しに応じる。
+     * Mekanism の Action と Forge の simulate フラグを橋渡しする。
+     */
+    @Override
+    public FloatingLong extractEnergy(int container, FloatingLong amount, Action action) {
+        if (container != 0) return FloatingLong.ZERO;
+        if (amount.isZero()) return FloatingLong.ZERO;
+        // amount を int に clamp してから BackpackFeStorage.extractEnergy を叩く。
+        int requested = (int) Math.min(Integer.MAX_VALUE, amount.longValue());
+        int extracted = storage.extractEnergy(requested, action.simulate());
+        return FloatingLong.createConst(extracted);
+    }
+}

--- a/src/main/java/backpackarsenal/energy/BackpackFeEvents.java
+++ b/src/main/java/backpackarsenal/energy/BackpackFeEvents.java
@@ -4,7 +4,12 @@ import backpackarsenal.BackpackArsenalMod;
 import backpackarsenal.init.ArsenalBackpackConfig;
 import backpackarsenal.init.ArsenalBlocks;
 import backpackarsenal.item.VoltaicBladeItem;
+import backpackarsenal.upgrade.VoltaicChargerUpgradeItem;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.util.LazyOptional;
@@ -15,6 +20,7 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
+import net.p3pp3rf1y.sophisticatedbackpacks.backpack.BackpackBlockEntity;
 
 import java.lang.reflect.Field;
 import java.util.Collections;
@@ -40,10 +46,22 @@ public class BackpackFeEvents {
 
     private static final ResourceLocation CAP_KEY =
         new ResourceLocation(BackpackArsenalMod.MODID, "fe");
+    private static final ResourceLocation ITEM_CAP_KEY =
+        new ResourceLocation(BackpackArsenalMod.MODID, "blade_fe");
 
     /** tracked placed-backpack BEs (weak → BE が GC されたら自動消滅)。 */
     private static final Map<BlockEntity, BackpackFeProvider> tracked =
         Collections.synchronizedMap(new WeakHashMap<>());
+
+    /** voltaic_blade ItemStack に IEnergyStorage を attach。 Mekanism cube / 他 FE 充電器で
+     *  blade を充電できるようにする。 */
+    @SubscribeEvent
+    public static void onAttachItem(AttachCapabilitiesEvent<ItemStack> event) {
+        ItemStack stack = event.getObject();
+        if (stack.getItem() instanceof VoltaicBladeItem) {
+            event.addCapability(ITEM_CAP_KEY, new VoltaicBladeEnergyProvider(stack));
+        }
+    }
 
     @SubscribeEvent
     public static void onAttachBlockEntity(AttachCapabilitiesEvent<BlockEntity> event) {
@@ -67,6 +85,12 @@ public class BackpackFeEvents {
         // → reflection で energyStorageCap を 我々の storage を保持する
         //   LazyOptional に上書きし、 SB の getCapability(ENERGY) が我々の値を返すようにする。
         injectIntoSbEnergyField(be, provider);
+
+        // Mekanism がロードされていれば、 Mekanism native の STRICT_ENERGY cap も付与する。
+        // これで Mekanism cube / cable は backpack を "Mekanism native の発電機" として認識し、
+        // Forge FE ↔ Joules ブリッジ ( config に依存) を経由せず直接連携する。
+        // Mekanism 未導入環境では何もしない ( class isolation で NoClassDefFoundError を回避)。
+        backpackarsenal.compat.mekanism.MekanismCompat.tryAttachStrictEnergy(event, provider);
 
         BackpackArsenalMod.LOGGER.info(
             "[backpack_arsenal] FE cap attached to BE @ {} (tracked={})",
@@ -109,8 +133,8 @@ public class BackpackFeEvents {
         if (event.level.isClientSide) return;
         if (event.level.getGameTime() % 10 != 0) return;
 
-        int chargePerInterval = VoltaicBladeItem.CHARGE_PER_TICK_IN_BACKPACK * 10;
-        int fePerInterval = ArsenalBackpackConfig.feGenPerTick * 10;
+        int baseChargePerInterval = VoltaicBladeItem.CHARGE_PER_TICK_IN_BACKPACK * 10;
+        int baseFePerInterval = ArsenalBackpackConfig.feGenPerTick * 10;
         int totalGenerated = 0;
         int ticked = 0;
         // 診断用: tick したけど発電 0 だった BE の状態を 1 つだけ拾う
@@ -126,6 +150,27 @@ public class BackpackFeEvents {
                 if (be.getLevel() != event.level) continue;
 
                 BackpackFeProvider provider = entry.getValue();
+
+                // VoltaicChargerUpgrade の倍率を計算 (手持ち backpack と同じロジック)。
+                //   upgrade 無し           → 1x
+                //   tier I (256bonus) 1枚  → 2x
+                //   tier I + tier II       → 4x (tier II bonus 512 = +2)
+                //   ...etc
+                int multiplier = 1 + sumVoltaicChargerContributions(be);
+                int chargePerInterval = baseChargePerInterval * multiplier;
+                int fePerInterval = baseFePerInterval * multiplier;
+
+                // Mekanism cable 等への 1 回限りの再検出通知。
+                // AttachCapabilitiesEvent は BE constructor 中で level==null なので
+                // 通知できない → 最初の tick で実行する。
+                if (!provider.notifiedNeighbors && be.getLevel() != null) {
+                    provider.notifiedNeighbors = true;
+                    be.getLevel().updateNeighborsAt(be.getBlockPos(), be.getBlockState().getBlock());
+                    BackpackArsenalMod.LOGGER.info(
+                        "[backpack_arsenal] notified neighbors about FE provider @ {}",
+                        be.getBlockPos());
+                }
+
                 final int[] genThisTick = {0};
                 final String[] reason = {null};
                 var handlerOpt = be.getCapability(ForgeCapabilities.ITEM_HANDLER);
@@ -148,6 +193,14 @@ public class BackpackFeEvents {
                     totalGenerated += genThisTick[0];
                     ticked++;
                 }
+
+                // 中の Mekanism tool 等 (IEnergyStorage cap 持ち) に FE を配布。
+                // voltaic_blade は直接充電してるのでスキップ。
+                handlerOpt.ifPresent(handler -> distributeFeToItemsInside(handler, provider.storage));
+
+                // 隣接 FE 受け取り手に PUSH (Mekanism cable / 直接 cube / 他 mod の FE 機械)。
+                // PULL に頼らない発電機の標準パターン。
+                pushFeToNeighbors(be, provider);
             }
         }
 
@@ -166,12 +219,121 @@ public class BackpackFeEvents {
         }
     }
 
+    /** 設置 backpack の BE から VoltaicChargerUpgrade の倍率寄与を合計する。
+     *  手持ち backpack 用の {@code BackpackChargingHandler#sumVoltaicChargerContributions}
+     *  と同じ計算を、 ItemStack でなく BlockEntity から取った wrapper に対して行う。
+     *  各 wrapper の {@link VoltaicChargerUpgradeItem.Wrapper#getMultiplierContribution()}
+     *  ( = (tier+1)^2 ) を全部足す。 */
+    private static int sumVoltaicChargerContributions(BlockEntity be) {
+        if (!(be instanceof BackpackBlockEntity sbBe)) return 0;
+        try {
+            var wrapper = sbBe.getBackpackWrapper();
+            if (wrapper == null) return 0;
+            var matched = wrapper.getUpgradeHandler().getTypeWrappers(VoltaicChargerUpgradeItem.TYPE);
+            int s = 0;
+            for (var w : matched) {
+                if (w != null && w.isEnabled()) s += w.getMultiplierContribution();
+            }
+            return s;
+        } catch (Throwable t) {
+            return 0;
+        }
+    }
+
     /** chargeBladesAndReport の戻り値。 診断ログ用に詳細を返す。 */
     private static final class ChargeReport {
         boolean chargedAny;
         int slotsScanned;
         int bladesFound;
         int bladesAlreadyFull;
+    }
+
+    /** backpack 内部の各スロットを走査し、 {@link IEnergyStorage} cap を持っていて
+     *  receiveEnergy 可能なアイテム ( = Mekanism tool / 他 mod のバッテリ式アイテム ) に
+     *  storage から FE を配る。 voltaic_blade は別経路で充電されてるのでスキップ。 */
+    private static void distributeFeToItemsInside(IItemHandler handler, BackpackFeStorage storage) {
+        for (int slot = 0; slot < handler.getSlots(); slot++) {
+            if (storage.getEnergyStored() <= 0) return;
+            ItemStack inner = handler.getStackInSlot(slot);
+            if (inner.isEmpty()) continue;
+            if (inner.getItem() instanceof VoltaicBladeItem) continue;
+            final int[] accepted = {0};
+            inner.getCapability(ForgeCapabilities.ENERGY).ifPresent(target -> {
+                if (!target.canReceive()) return;
+                int available = storage.extractEnergy(Integer.MAX_VALUE, true);
+                if (available <= 0) return;
+                accepted[0] = target.receiveEnergy(available, false);
+                if (accepted[0] > 0) storage.extractEnergy(accepted[0], false);
+            });
+            // 永続化: SB の wrapper は setStackInSlot を呼ばないと NBT 変更を保存しない場合が
+            // あるため明示的に書き戻す。 voltaic_blade と同じ ChargingHandler の挙動。
+            if (accepted[0] > 0 && handler instanceof IItemHandlerModifiable mod) {
+                mod.setStackInSlot(slot, inner);
+            }
+        }
+    }
+
+    /** 隣接 6 方向の FE 受け取り手に PUSH。 storage に貯まってる分を上限まで押し込む。 */
+    private static long lastPushLogMs = 0;
+    private static long lastDiagLogMs = 0;
+    private static void pushFeToNeighbors(BlockEntity be, BackpackFeProvider provider) {
+        Level level = be.getLevel();
+        if (level == null) return;
+        if (provider.storage.getEnergyStored() <= 0) return;
+
+        BlockPos pos = be.getBlockPos();
+        int totalPushed = 0;
+        StringBuilder diag = new StringBuilder();
+        for (Direction dir : Direction.values()) {
+            if (provider.storage.getEnergyStored() <= 0) break;
+            BlockPos adjPos = pos.relative(dir);
+            BlockEntity adj = level.getBlockEntity(adjPos);
+            if (adj == null) {
+                // 隣接にブロックは有るけど BE が無い場合がある (vanilla block 等)
+                diag.append(dir.getName()).append("=no-be ");
+                continue;
+            }
+            String adjClass = adj.getClass().getSimpleName();
+            var capOpt = adj.getCapability(ForgeCapabilities.ENERGY, dir.getOpposite());
+            if (!capOpt.isPresent()) {
+                diag.append(dir.getName()).append("=").append(adjClass).append("(no-cap) ");
+                continue;
+            }
+            int pushed = capOpt.map(target -> {
+                if (!target.canReceive()) return -1; // -1 でフラグ
+                int available = provider.storage.extractEnergy(Integer.MAX_VALUE, true);
+                if (available <= 0) return 0;
+                int accepted = target.receiveEnergy(available, false);
+                if (accepted > 0) provider.storage.extractEnergy(accepted, false);
+                return accepted;
+            }).orElse(0);
+            if (pushed == -1) {
+                diag.append(dir.getName()).append("=").append(adjClass).append("(no-receive) ");
+            } else if (pushed > 0) {
+                totalPushed += pushed;
+                diag.append(dir.getName()).append("=").append(adjClass).append("(+").append(pushed).append(") ");
+            } else {
+                diag.append(dir.getName()).append("=").append(adjClass).append("(accepted=0) ");
+            }
+        }
+
+        long now = System.currentTimeMillis();
+        if (totalPushed > 0 && now - lastPushLogMs > 4000) {
+            lastPushLogMs = now;
+            BackpackArsenalMod.LOGGER.info(
+                "[backpack_arsenal] FE pushed: {} FE (storage {}/{}) — {}",
+                totalPushed, provider.storage.getEnergyStored(),
+                provider.storage.getMaxEnergyStored(), diag.toString().trim());
+        } else if (totalPushed == 0 && now - lastDiagLogMs > 4000
+                   && provider.storage.getEnergyStored() > 0) {
+            // FE は貯まってるのに 1 つも送れない時の診断ログ
+            lastDiagLogMs = now;
+            BackpackArsenalMod.LOGGER.info(
+                "[backpack_arsenal] FE push had no takers (storage {}/{}): {}",
+                provider.storage.getEnergyStored(),
+                provider.storage.getMaxEnergyStored(),
+                diag.length() == 0 ? "no adjacent blocks" : diag.toString().trim());
+        }
     }
 
     /** ハンドラ内の voltaic_blade を充電し、 1 本でも充電できた (= 満タンでなかった) かを返す。

--- a/src/main/java/backpackarsenal/energy/BackpackFeProvider.java
+++ b/src/main/java/backpackarsenal/energy/BackpackFeProvider.java
@@ -21,6 +21,10 @@ public class BackpackFeProvider implements ICapabilitySerializable<CompoundTag> 
 
     public final BackpackFeStorage storage;
     private final LazyOptional<IEnergyStorage> opt;
+    /** 隣接ブロック更新を 1 回だけ発火させたかのフラグ。
+     *  Mekanism cable は隣接 BE に capability が「後から」付いたことに気付けないため、
+     *  level がセットされた最初の tick で neighbor update を送って再検出させる。 */
+    public boolean notifiedNeighbors = false;
 
     public BackpackFeProvider(int capacity, int maxExtract) {
         this.storage = new BackpackFeStorage(capacity, maxExtract);

--- a/src/main/java/backpackarsenal/energy/VoltaicBladeEnergyProvider.java
+++ b/src/main/java/backpackarsenal/energy/VoltaicBladeEnergyProvider.java
@@ -1,0 +1,31 @@
+package backpackarsenal.energy;
+
+import net.minecraft.core.Direction;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.energy.IEnergyStorage;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * voltaic_blade ItemStack に {@link VoltaicBladeEnergyStorage} を attach する
+ * ICapabilityProvider。 NBT 永続化は不要 ( BackpackCharge は元から ItemStack NBT
+ * で永続化されてる )。
+ */
+public class VoltaicBladeEnergyProvider implements ICapabilityProvider {
+
+    private final LazyOptional<IEnergyStorage> opt;
+
+    public VoltaicBladeEnergyProvider(ItemStack stack) {
+        this.opt = LazyOptional.of(() -> new VoltaicBladeEnergyStorage(stack));
+    }
+
+    @NotNull
+    @Override
+    public <T> LazyOptional<T> getCapability(@NotNull Capability<T> cap, @Nullable Direction side) {
+        return cap == ForgeCapabilities.ENERGY ? opt.cast() : LazyOptional.empty();
+    }
+}

--- a/src/main/java/backpackarsenal/energy/VoltaicBladeEnergyStorage.java
+++ b/src/main/java/backpackarsenal/energy/VoltaicBladeEnergyStorage.java
@@ -1,0 +1,69 @@
+package backpackarsenal.energy;
+
+import backpackarsenal.item.VoltaicBladeItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.energy.IEnergyStorage;
+
+/**
+ * voltaic_blade の {@link IEnergyStorage} 実装。 ItemStack の NBT
+ * "BackpackCharge" を Forge Energy の単位 (FE) として公開する wrapper。
+ *
+ * 変換: {@link #FE_PER_CHARGE} FE = 1 BackpackCharge ユニット。
+ * voltaic_blade の最大チャージは rarity で 1024〜12288 なので、 FE 換算では
+ * 102,400〜1,228,800 FE。
+ *
+ * 受け取り専用 (canExtract = false)。 外部 (Mekanism cube / induction matrix /
+ * Create's electric conduit など) から FE を流し込んで blade をチャージできる。
+ */
+public class VoltaicBladeEnergyStorage implements IEnergyStorage {
+
+    /** 1 BackpackCharge を何 FE 相当で表すか。 */
+    public static final int FE_PER_CHARGE = 100;
+    /** 1 receiveEnergy 呼び出しあたりの受け入れ上限 (= 充電速度の rate-limit)。
+     *  Mekanism cube は無制限に push するので、 ここで絞らないと 1 tick で満タンに
+     *  なってしまう。 1000 FE/tick = 10 charge/tick = 200 charge/秒。 */
+    public static final int MAX_RECEIVE_PER_CALL = 1000;
+
+    private final ItemStack stack;
+
+    public VoltaicBladeEnergyStorage(ItemStack stack) {
+        this.stack = stack;
+    }
+
+    @Override
+    public int getEnergyStored() {
+        return VoltaicBladeItem.getCharge(stack) * FE_PER_CHARGE;
+    }
+
+    @Override
+    public int getMaxEnergyStored() {
+        return VoltaicBladeItem.getMaxCharge(stack) * FE_PER_CHARGE;
+    }
+
+    @Override
+    public int receiveEnergy(int maxReceive, boolean simulate) {
+        int charge = VoltaicBladeItem.getCharge(stack);
+        int maxCharge = VoltaicBladeItem.getMaxCharge(stack);
+        if (charge >= maxCharge) return 0;
+
+        int feRoom = (maxCharge - charge) * FE_PER_CHARGE;
+        int accepted = Math.min(MAX_RECEIVE_PER_CALL, Math.min(maxReceive, feRoom));
+        int chargeToAdd = accepted / FE_PER_CHARGE;
+        if (chargeToAdd <= 0) return 0;
+        if (!simulate) {
+            VoltaicBladeItem.addCharge(stack, chargeToAdd);
+        }
+        return chargeToAdd * FE_PER_CHARGE;
+    }
+
+    @Override
+    public int extractEnergy(int maxExtract, boolean simulate) {
+        return 0; // blade からエネルギーを抜き取る用途は無い (= 受け取り専用)
+    }
+
+    @Override
+    public boolean canExtract() { return false; }
+
+    @Override
+    public boolean canReceive() { return true; }
+}

--- a/src/main/java/backpackarsenal/event/BackpackChargingHandler.java
+++ b/src/main/java/backpackarsenal/event/BackpackChargingHandler.java
@@ -99,6 +99,10 @@ public class BackpackChargingHandler {
             chargeKatanasInHandler(handler, chargeAmount));
     }
 
+    /** 手持ち backpack 内の Mekanism tool 等 ( IEnergyStorage cap 持ち ) に 1 回で
+     *  渡せる FE 量。 voltaic_blade と同じ感覚で 10 tick あたり ~2000 FE = 200 FE/tick = 4000 FE/秒。 */
+    private static final int HELD_FE_PER_INTERVAL = 2000;
+
     /** IItemHandler を再帰的に走査（ネストしたバックパックにも対応） */
     private static void chargeKatanasInHandler(IItemHandler handler, int chargeAmount) {
         for (int slot = 0; slot < handler.getSlots(); slot++) {
@@ -119,6 +123,18 @@ public class BackpackChargingHandler {
             } else if (isSophisticatedBackpack(inner)) {
                 // ネストされたバックパックの中身もチャージ対象に
                 chargeAllKatanasInside(inner, chargeAmount);
+            } else {
+                // Mekanism tool / 他 mod のバッテリ式アイテム ( IEnergyStorage cap 持ち ) も充電。
+                // 設置 backpack と違って FE バッファが無いので一定量を直接渡す。
+                inner.getCapability(net.minecraftforge.common.capabilities.ForgeCapabilities.ENERGY)
+                    .ifPresent(target -> {
+                        if (target.canReceive() && target.getEnergyStored() < target.getMaxEnergyStored()) {
+                            target.receiveEnergy(HELD_FE_PER_INTERVAL, false);
+                        }
+                    });
+                if (handler instanceof IItemHandlerModifiable mod) {
+                    mod.setStackInSlot(slot, inner);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- `MekanismEnergyAdapter` wraps `BackpackFeStorage` as Mekanism's native `IStrictEnergyHandler` so cube / cable / induction matrix see the backpack as a Mekanism-native generator (skipping the Forge FE ↔ Joules bridge).
- `MekanismCompat` is a class-isolated dispatcher — the Mekanism API types live in `MekanismEnergyAdapter` only, and JVM lazy class loading keeps Mekanism-absent environments safe.
- voltaic_blade now exposes `IEnergyStorage` (1 charge = 100 FE) so Mekanism cubes / induction cells can charge the blade externally.
- Held + placed backpack now distribute FE to internal Mekanism tools (e.g. Atomic Disassembler) and push to adjacent FE receivers.

## Test plan
- [x] `./gradlew compileJava --offline` (without Mekanism)
- [x] `./gradlew compileJava --offline -PwithMekanism=true`
- [ ] In dev: arsenal_backpack with voltaic_blade inside → Mekanism Basic Energy Cube adjacent → cube fills up
- [ ] In dev: Mekanism Atomic Disassembler in backpack → FE in tool tooltip increases
- [ ] In dev: voltaic_blade in Mekanism cube charge slot → BackpackCharge NBT increases

🤖 Generated with [Claude Code](https://claude.com/claude-code)