### PR TITLE
fix(ci): use curl --form-string for CF metadata to escape ';' safely

### DIFF
--- a/.github/workflows/cf-upload.yml
+++ b/.github/workflows/cf-upload.yml
@@ -240,10 +240,15 @@ jobs:
         if: steps.parse.outputs.skip != 'true' && steps.parse.outputs.release_type != 'test'
         run: |
           echo "::notice::POST $(basename $JAR_PATH) ($JAR_SIZE) as $RELEASE_TYPE ..."
+          # 重要: metadata は --form-string を使う ( -F だと値中の ';' を curl が
+          # サブオプション区切り (例: ';type=...') と誤解釈して JSON を分裂させてしまい、
+          # CF が "Error in field `metadata`: Invalid JSON" (errorCode 1002) で 落ちる。
+          # 過去事象: commit subject に ';' を含む changelog (例: "bumps; bump to 1.0.4") を
+          # CHANGELOG として 詰めた時に再現。 --form-string は値を 完全 literal で扱うので安全。
           HTTP=$(curl --progress-bar \
             -o response.json -w "%{http_code}" \
             -H "X-Api-Token: $CF_TOKEN" \
-            -F "metadata=$METADATA" \
+            --form-string "metadata=$METADATA" \
             -F "file=@$JAR_PATH" \
             "https://minecraft.curseforge.com/api/projects/$CF_PROJECT_ID/upload-file")
           echo "::notice::upload HTTP $HTTP"


### PR DESCRIPTION
## Summary
- Replace \`-F \"metadata=\$METADATA\"\` with \`--form-string \"metadata=\$METADATA\"\` in the CurseForge upload step.
- Root cause: \`curl -F\` parses \`;\` inside the value as a sub-option separator (\`;type=...\`, \`;filename=...\`, etc.). When the auto-generated changelog embedded a commit subject containing \`;\` (e.g. \`"bumps; bump to 1.0.4"\` from \`be536b9\`), curl split the JSON at that \`;\` and emitted multiple bogus form fields. CurseForge then received truncated/broken JSON in the \`metadata\` field and rejected the upload with HTTP 400 \`errorCode 1002\` ("Error in field metadata: Invalid JSON").
- \`--form-string\` treats the value verbatim with no sub-option parsing, so future changelog content (including \`;\`, \`<\`, \`@\`) is always safe.

## Test plan
- [ ] Re-trigger the build → approval flow on main, tick a release type and close the approval issue.
- [ ] The \`Upload to CurseForge\` step posts the same kind of changelog (semicolons preserved) and now returns HTTP 200.
- [ ] CurseForge page lists the new release file.