### PR TITLE
feat(ci): auto-create CF approval issue on every non-dependabot PR merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,8 +100,17 @@ jobs:
                     RELEASE_TYPE="alpha"
                   fi
                 fi
+              elif [[ "$PR_HEAD" == dependabot/* ]]; then
+                # dependabot は dep bump 専用なので 毎回 approval issue が立つと spammy。
+                # 必要なら workflow_dispatch で 手動 trigger する。
+                echo "::notice::push from dependabot PR ($PR_HEAD) — skip CF upload"
               else
-                echo "::notice::push from non-release PR (head='$PR_HEAD', e.g. dependabot) — skip CF upload"
+                # 通常 PR ( feat/* fix/* chore/* docs/* 等) は alpha approval issue を作る。
+                # 不要なら issue で 何も tick せず close すれば skip される ( cf-upload.yml が
+                # 「tick 無し close」 を 「キャンセル扱い」 として 何もしない )。
+                RELEASE_TYPE="alpha"
+                SHOULD_UPLOAD="true"
+                echo "::notice::push from PR ($PR_HEAD) — alpha approval issue will be created"
               fi
             fi
           fi


### PR DESCRIPTION
## Summary
- Before: only \`release/*\` PR heads triggered the CurseForge approval-issue path. After merging a \`feat/\` or \`fix/\` PR, the maintainer had to remember to run \`gh workflow run build.yml -f release_type=alpha\` manually to get the approval issue.
- After: any PR merge generates an alpha-default approval issue automatically. Tick a release type and close to upload, or close without ticking to cancel (cf-upload.yml treats no-tick close as a skip).
- \`dependabot/*\` PRs stay on the skip path — dep bumps rarely warrant a new CF release and auto-issuing them would spam the issue list.

## Test plan
- [ ] Merge this PR → main push fires build.yml → Build job succeeds → \`create_approval_issue\` job runs → new CF approval issue appears
- [ ] Verify the issue title is \`CF approval: backpack-arsenal <version>\` and the default-type row shows \`alpha\`
- [ ] Later: merge a dependabot PR → confirm no approval issue is created (notice log shows \`skip CF upload\`)